### PR TITLE
Fix placeholder text for qc status

### DIFF
--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -313,7 +313,7 @@ def main(url_duration, snv_path=None, cnv_path=None,bed_file=None,qc_status=None
     if qc_status is not None:
         qc_status_url = make_url(qc_status, DX_PROJECT,url_duration)
     else:
-        qc_status_url = 'No qc_status bed file provided'
+        qc_status_url = 'No QC status file provided'
 
     data = {}
 


### PR DESCRIPTION
When qc status file missing the test read 'No qc_status bed file provided', changed to be accurate 'No QC status file provided' just string changed no functional changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/2)
<!-- Reviewable:end -->
