### PR TITLE
Di 289 Update name mapping

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,10 +3,7 @@
   "title": "eggd_artemis",
   "summary": "Gathers required files and creates file containing urls for them",
   "dxapi": "1.0.0",
-  "version": "1.1.0",
-  "properties": {
-    "githubRelease": "1.1.0"
-    },
+  "version": "1.2.0",
   "inputSpec": [
     {
       "name": "snv_path",

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -539,7 +539,7 @@ def write_output_file(
     df = pd.DataFrame(columns=['a', 'b'])
     df = df.append({'a': 'Run:', 'b': project_name}, ignore_index=True)
     df = df.append({}, ignore_index=True)
-    df = df.append({'a': 'Date Crated:', 'b': today}, ignore_index=True)
+    df = df.append({'a': 'Date Created:', 'b': today}, ignore_index=True)
     df = df.append({'a': 'Expiry Date:', 'b': expiry_date}, ignore_index=True)
     df = df.append({}, ignore_index=True)
     df = df.append({'a': 'Run Level Files'}, ignore_index=True)

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -187,7 +187,7 @@ def get_cnv_file_ids(reports, gcnv_dict):
         # gCNV job has all input bams and all outputs go through info
         # saved in the dictionary and find the sample specific files required
         for k, v in gcnv_dict.items():
-            if k.startswith(f'{sample}-'):
+            if k.startswith(f'{sample}'):
                 if k.endswith(".bam"):
                     bam = v
                 elif k.endswith(".bai"):


### PR DESCRIPTION
New dias batch names xlsx reports with the full file name not just the first field. This caused the app to fail as it was trying to match for the first field followed by a dash which doesn't match the full name.

Changes:

- Increment app version (remove github release in properties)
- Removed dash in line 190 and matching on the full file string. (closes #11 )
- Fixed typo in output file (closes #9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/12)
<!-- Reviewable:end -->
