### PR TITLE
DI-601 v1.4.0 Variant counts and multiple reports per sample

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ Gathers required files and creates file containing urls to allow file download w
 * `url_duration`[optional]: Time (in seconds) until the generated links expire. (Default = 4838400)
 * `bed_file`[optional]: Static capture bed file
 * `qc_status`[optional]: Input of xlsx file containing agreed QC status for samples in the run
+* `multiqc_report`[optional]: Input of the MultiQC report - if not provided, will search for a MultiQC job in the project to find this
+* `lock_cells`[optional]: Determines whether to protect any populated cells in the output .xlsx from editing (Default=True)
 
 ## How does this app work?
 

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ Gathers required files and creates file containing urls to allow file download w
 ## What inputs are required for this app to run?
 * `snv_path`[optional]: List of absolute paths to folder containing the variant reports for small variants
 * `cnv_path`[optional]: List of absolute paths to folder containing the variant reports for CNVs
-* `url_duration`[optional]: Time (in seconds) until the generated links expire. (Default = 1209600)
+* `url_duration`[optional]: Time (in seconds) until the generated links expire. (Default = 4838400)
 * `bed_file`[optional]: Static capture bed file
 * `qc_status`[optional]: Input of xlsx file containing agreed QC status for samples in the run
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -40,6 +40,21 @@
       "class": "file",
       "optional": true,
       "help": ""
+    },
+    {
+      "name": "multiqc_report",
+      "label": "MultiQC report",
+      "class": "file",
+      "optional": true,
+      "help": "MultiQC report. If not provided, will search for a MultiQC job in the project"
+    },
+    {
+      "name": "lock_cells",
+      "label": "Lock populated Excel cells",
+      "class": "boolean",
+      "optional": true,
+      "default": true,
+      "help": "Boolean which controls whether to lock any cells for editing if they are populated in the Excel output file"
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_artemis",
   "summary": "Gathers required files and creates file containing urls for them",
   "dxapi": "1.0.0",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "inputSpec": [
     {
       "name": "snv_path",

--- a/dxapp.json
+++ b/dxapp.json
@@ -45,7 +45,7 @@
   "outputSpec": [
     {
       "name": "url_file",
-      "label": "File contraining download links",
+      "label": "File containing download links",
       "class": "file",
       "patterns": [
         "*"

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -610,10 +610,16 @@ def write_output_file(
         for field, label in url_fields.items():
             if urls.get(field):
                 if field == 'SNV count':
+                    # If SNV count exists and 0 variants pass filtering
+                    # Remove the SNV report URL altogether and replace with
+                    # NMD text
                     if int(urls.get(field)) == 0:
-                        urls['snv_url'] = 'No SNVs pass filtering'
+                        urls['snv_url'] = 'No SNVs passed filtering'
 
                 if field == 'CNV count':
+                    # If CNV count exists and 0 variants pass filtering
+                    # Remove the CNV report URL altogether and replace with
+                    # NMD text
                     if (int(urls.get(field)) == 0):
                         urls['cnv_url'] = 'No CNVs detected'
 

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -701,6 +701,7 @@ def main(url_duration, snv_path=None, cnv_path=None, bed_file=None, qc_status=No
 
     # Get name of project for output naming
     project_name = dxpy.describe(DX_PROJECT)['name']
+    project_name = '_'.join(project_name.split('_')[1:-1])
 
     # Gather required SNV files if SNV path is provided
     multiqc = None

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -44,9 +44,9 @@ def find_snv_files(reports):
         sample = report['describe']['name'].split("_")[0]
 
         # Get the 'details' of the SNV xlsx report to return the number of
-        # include (non-filtered) variants
-        # If the xlsx has no details this will be empty response i.e. '{}' so
-        # calling get for the include_variants key will result in None
+        # variants remaining after filtering
+        # If the xlsx has no 'details' the response will be empty i.e. '{}'
+        # so getting the include_variants key will return None
         snv_variant_count = dxpy.bindings.dxdataobject_functions.get_details(
             report['id']
         ).get('include_variants')
@@ -193,8 +193,8 @@ def get_cnv_file_ids(reports, gcnv_dict):
         sample = report['describe']['name'].split("_")[0]
 
         # Get the 'details' of the CNV xlsx report to get number of variants
-        # If file has no details this will be empty response i.e. '{}' so
-        # calling get for the include_variants key will result in None
+        # If the xlsx has no 'details' the response will be empty i.e. '{}'
+        # so getting the include_variants key will return None
         cnv_variant_counts = dxpy.bindings.dxdataobject_functions.get_details(
             report['id']
         ).get('include_variants')

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -570,12 +570,17 @@ def write_output_file(
     """
     print("Writing output file")
 
+    sample_urls_plus_metadata = merge(sample_urls, file_dict)
+    sample_count = str(len(sample_urls_plus_metadata.keys()))
+
     multiqc_url = f'=HYPERLINK("{multiqc_url}", "{multiqc_url}")'
     if qc_url.startswith('http'):
         qc_url = f'=HYPERLINK("{qc_url}", "{qc_url}")'
 
     df = pd.DataFrame(columns=['a', 'b'])
     df = df.append({'a': 'Run:', 'b': project_name}, ignore_index=True)
+    df = df.append({'a': 'Number of samples released:', 'b': sample_count},
+    ignore_index=True)
     df = df.append({}, ignore_index=True)
     df = df.append({'a': 'Date Created:', 'b': today}, ignore_index=True)
     df = df.append({'a': 'Expiry Date:', 'b': expiry_date}, ignore_index=True)
@@ -587,8 +592,6 @@ def write_output_file(
     df = df.append({}, ignore_index=True)
     df = df.append({'a': 'Per Sample Files'}, ignore_index=True)
     df = df.append({}, ignore_index=True)
-
-    sample_urls_plus_metadata = merge(sample_urls, file_dict)
 
     sample_order = sorted(sample_urls_plus_metadata.keys())
 
@@ -640,12 +643,13 @@ def write_output_file(
 
     # set column widths
     sheet = writer.sheets['Sheet1']
-    sheet.column_dimensions['A'].width = 20
+    sheet.column_dimensions['A'].width = 28
     sheet.column_dimensions['B'].width = 145
 
     sheet['A1'].font = Font(bold=True, name=DEFAULT_FONT.name)
-    sheet['A6'].font = Font(bold=True, name=DEFAULT_FONT.name)
-    sheet['A11'].font = Font(bold=True, name=DEFAULT_FONT.name)
+    sheet['A2'].font = Font(bold=True, name=DEFAULT_FONT.name)
+    sheet['A7'].font = Font(bold=True, name=DEFAULT_FONT.name)
+    sheet['A12'].font = Font(bold=True, name=DEFAULT_FONT.name)
 
     # make sample IDs bold
     for cell in sheet.iter_rows(max_col=1):
@@ -696,7 +700,7 @@ def main(url_duration, snv_path=None, cnv_path=None, bed_file=None, qc_status=No
 
     # Get name of project for output naming
     project_name = dxpy.describe(DX_PROJECT)['name']
-    project_name = '_'.join(project_name.split('_')[1:-1])
+    project_name = dxpy.describe(DX_PROJECT)['name']
 
     # Gather required SNV files if SNV path is provided
     multiqc = None

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -627,6 +627,7 @@ def write_output_file(
                     # NMD text
                     if (int(urls.get(field)) == 0):
                         urls['cnv_url'] = 'No CNVs detected'
+                        urls['cnv_session_url'] = 'No CNVs detected'
 
                 if field == 'bam_url':
                     df = df.append({}, ignore_index=True)

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -552,7 +552,8 @@ def write_output_file(
     sample_urls : dict
         generated URLs for each sample
     file_dict : dict
-        dict created earlier with variant counts
+        dict created earlier with SNV/CNV reports for all samples which
+        includes variant counts
     today : str
         today date
     expiry_date : str
@@ -699,7 +700,6 @@ def main(url_duration, snv_path=None, cnv_path=None, bed_file=None, qc_status=No
             "parents": True})
 
     # Get name of project for output naming
-    project_name = dxpy.describe(DX_PROJECT)['name']
     project_name = dxpy.describe(DX_PROJECT)['name']
 
     # Gather required SNV files if SNV path is provided

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -43,8 +43,9 @@ def find_snv_files(reports):
         # Get sample name
         sample = report['describe']['name'].split("_")[0]
 
-        # Get the 'details' of the SNV xlsx report
-        # If file has no details this will be empty response i.e. '{}' so
+        # Get the 'details' of the SNV xlsx report to return the number of
+        # include (non-filtered) variants
+        # If the xlsx has no details this will be empty response i.e. '{}' so
         # calling get for the include_variants key will result in None
         snv_variant_count = dxpy.bindings.dxdataobject_functions.get_details(
             report['id']
@@ -191,7 +192,7 @@ def get_cnv_file_ids(reports, gcnv_dict):
         """
         sample = report['describe']['name'].split("_")[0]
 
-        # Get the 'details' of the CNV xlsx report
+        # Get the 'details' of the CNV xlsx report to get number of variants
         # If file has no details this will be empty response i.e. '{}' so
         # calling get for the include_variants key will result in None
         cnv_variant_counts = dxpy.bindings.dxdataobject_functions.get_details(


### PR DESCRIPTION
**Changes**
- Adds number of samples released in the links file
- Adds SNV/CNV counts and clinical indication in Excel report if available
  - If counts available, removes SNV or CNV report download URLs if no SNVs pass filtering/no CNVs detected
- Allows releasing of multiple SNV and CNV reports per sample (i.e. if reports are split by clinical indication because Dias batch was run with -isplit_tests=true)
  - Orders SNV and CNV reports by panel (if present) 
  - Names CNV IGV session files using part of CNV report name so they are named differently if multiple session files are made for the same sample
- Adds optional input `-ilock_cells` which locks any Excel cells which are populated from editing (default True)
- Adds optional input `-imultiqc_report` of MultiQC report file (closes #18)
- Updates README to include the correct default URL duration (closes #17)
- Fixes typo in dxapp.json (closes #15)

**Example test jobs**
**New format**
Excel report metadata (clinical indications and variant counts) present, reports split per sample by panel, cells locked, MultiQC report given as input. One sample (line 586) is split into multiple reports.
Job: https://platform.dnanexus.com/panx/projects/Gf1JZfQ4FBj30ZjFQjKp3FQ3/data/?scope=project&id.values=file-GfPGxJ84FBjFB9P06Qf0q1F9

**As current set up**
No Excel report metadata (counts or clinical indications) present for these reports so no clinical indications or counts present or links removed in final Excel. Reports aren't split by clinical indication so only a single report given back per sample. Excel cells not locked for editing
Job: https://platform.dnanexus.com/panx/projects/Gf1JZfQ4FBj30ZjFQjKp3FQ3/monitor/job/GfPv29Q4FBjFb5y3ykXk7P08

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/19)
<!-- Reviewable:end -->
