### PR TITLE
Fix logic for keeping download links

### DIFF
--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -720,26 +720,28 @@ def remove_url_if_variant_count_is_zero(
         for clin_ind in sample_data['clinical_indications']:
             file_data = sample_data['clinical_indications'][clin_ind]
 
+            # If variant count was never present then replace with None
+            # so we can easily not include this field in final .xlsx
             # If snv_reports option True, replace SNV report URL with text
-            # if variant count is zero. If variant count was never present
-            # then replace with None so we can easily not include this field
-            # in final .xlsx
-            if snv_reports:
-                if 'SNV' in file_data:
-                    for file in file_data['SNV']:
+            # if variant count is zero.
+            if 'SNV' in file_data:
+                for file in file_data['SNV']:
+                    if file.get('SNV count') == 'Unknown':
+                        file['SNV count'] = None
+                    if snv_reports:
                         if file.get('SNV count') == '0':
                             file['snv_url'] = 'No SNVs post-filtering'
-                        elif file.get('SNV count') == 'Unknown':
-                            file['SNV count'] = None
 
-            # If cnv_reports option True, do same for CNV report links
-            if cnv_reports:
-                if 'CNV' in file_data:
-                    for file in file_data['CNV']:
+            # Do same for CNV reports, remove CNV report link if
+            # cnv_reports option True
+            if 'CNV' in file_data:
+                for file in file_data['CNV']:
+                    if file.get('CNV count') == 'Unknown':
+                        file['CNV count'] = None
+                    if cnv_reports:
                         if file.get('CNV count') == '0':
                             file['cnv_url'] = 'No CNVs detected'
-                        elif file.get('CNV count') == 'Unknown':
-                            file['CNV count'] = None
+
 
     return all_sample_urls
 


### PR DESCRIPTION
- Last PR logic was slightly wrong as the SNV count / CNV count should always be set to None if file metadata not present but would only do so if we were removing download URLs for that variant type

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/21)
<!-- Reviewable:end -->
