### PR TITLE
v1.5.0 - find summary .txt file id

### DIFF
--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -102,7 +102,7 @@ def find_snv_files(reports):
         try:
             summary_text = parent_details["output"]["stage-rpt_athena.summary_text"]["$dnanexus_link"]
         except KeyError:
-            summary_text = ''
+            summary_text = None
             print(f"No summary .txt file found in output of eggd_athena stage"
                   f" for SNV reports workflow ({parent_details})")
 
@@ -692,12 +692,6 @@ def generate_sample_outputs(
                 snv_url = make_url(
                     snv_file['SNV variant report'], dx_project, url_duration
                 )
-                if
-                summary_text = dxpy.open_dxfile(
-                    snv_file['Summary text file'],
-                    project=dx_project,
-                    mode="r"
-                ).read()
 
                 outputs['clinical_indications'][clin_ind]['SNV'].append(
                     {

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -42,6 +42,7 @@ def find_snv_files(reports):
                         {
                             'SNV variant report': 'file-ZX',
                             'Coverage report': {'$dnanexus_link': 'file-GH'},
+                            'Summary text file': 'file-NM',
                             'SNV count': 1
                         }
                     ],
@@ -50,6 +51,7 @@ def find_snv_files(reports):
                         {
                             'SNV variant report': 'file-GH',
                             'Coverage report': {'$dnanexus_link': 'file-GH'},
+                            'Summary text file': 'file-JK',
                             'SNV count': 3
                         }
                     ]
@@ -97,9 +99,14 @@ def find_snv_files(reports):
             coverage_report = parent_details["output"]["stage-rpt_athena.report"]
         except KeyError:
             coverage_report = parent_details["output"]["stage-Fyq5z18433GfYZbp3vX1KqjB.report"]
+        try:
+            summary_text = parent_details["output"]["stage-rpt_athena.summary_text"]["$dnanexus_link"]
+        except KeyError:
+            print(f"No summary .txt file found in output of eggd_athena stage"
+                  f" for SNV reports workflow ({parent_details})")
 
         # Extract the sention job id from the vcf metadata
-        sention_job_id=dxpy.describe(vcf_file)["createdBy"]["job"]
+        sention_job_id = dxpy.describe(vcf_file)["createdBy"]["job"]
         sentieon_details = dxpy.bindings.dxjob.DXJob(dxid=sention_job_id).describe()
 
         # Get bam & bai job id from sention job metadata
@@ -117,6 +124,7 @@ def find_snv_files(reports):
                         {
                             "SNV variant report": report['describe']['id'],
                             "Coverage report": coverage_report,
+                            "Summary text file": summary_text,
                             "SNV count": str(snv_variant_count)
                         }
                     ]
@@ -411,10 +419,10 @@ def get_multiqc_report(path_to_reports, project):
         multiqc_file (str): file id of the multiqc file
     """
     # Get path to single from reports path
-    single=f"/output/{path_to_reports.split('/')[2]}"
+    single = f"/output/{path_to_reports.split('/')[2]}"
 
     # Find MultiQC jobs in the project
-    multiqc_reports=list(dxpy.bindings.search.find_jobs(
+    multiqc_reports = list(dxpy.bindings.search.find_jobs(
             name_mode='glob',
             name="*MultiQC*",
             state="done",

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -102,6 +102,7 @@ def find_snv_files(reports):
         try:
             summary_text = parent_details["output"]["stage-rpt_athena.summary_text"]["$dnanexus_link"]
         except KeyError:
+            summary_text = ''
             print(f"No summary .txt file found in output of eggd_athena stage"
                   f" for SNV reports workflow ({parent_details})")
 
@@ -691,6 +692,12 @@ def generate_sample_outputs(
                 snv_url = make_url(
                     snv_file['SNV variant report'], dx_project, url_duration
                 )
+                if
+                summary_text = dxpy.open_dxfile(
+                    snv_file['Summary text file'],
+                    project=dx_project,
+                    mode="r"
+                ).read()
 
                 outputs['clinical_indications'][clin_ind]['SNV'].append(
                     {
@@ -698,6 +705,7 @@ def generate_sample_outputs(
                         'coverage_url': (
                             f'=HYPERLINK("{coverage_url}", "{coverage_url}")'
                         ),
+                        'coverage_summary': summary_text
                         'snv_url': f'=HYPERLINK("{snv_url}", "{snv_url}")'
                     }
                 )

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -99,10 +99,9 @@ def find_snv_files(reports):
             coverage_report = parent_details["output"]["stage-rpt_athena.report"]
         except KeyError:
             coverage_report = parent_details["output"]["stage-Fyq5z18433GfYZbp3vX1KqjB.report"]
-        try:
-            summary_text = parent_details["output"]["stage-rpt_athena.summary_text"]["$dnanexus_link"]
-        except KeyError:
-            summary_text = None
+
+        summary_text = parent_details.get("output", {}).get("stage-rpt_athena.summary_text", {}).get("$dnanexus_link")
+        if not summary_text:
             print(f"No summary .txt file found in output of eggd_athena stage"
                   f" for SNV reports workflow ({parent_details})")
 

--- a/src/eggd_artemis.py
+++ b/src/eggd_artemis.py
@@ -699,7 +699,6 @@ def generate_sample_outputs(
                         'coverage_url': (
                             f'=HYPERLINK("{coverage_url}", "{coverage_url}")'
                         ),
-                        'coverage_summary': summary_text
                         'snv_url': f'=HYPERLINK("{snv_url}", "{snv_url}")'
                     }
                 )


### PR DESCRIPTION
- Added code to find summary text file by querying the output of eggd_athena stage of SNV reports workflow 
- [Example job which completes successfully](https://platform.dnanexus.com/panx/projects/GkbBjJ04Pqj2Q3J597Q3gKJx/monitor/job/GkygJgj4Pqj8QZ0KB5P2yJ50) run with a now removed print statement to show contents of the SNV data dictionary. See in logs (or screenshot below) for the presence of summary text file ID within the data dict.

![image](https://github.com/eastgenomics/eggd_artemis/assets/134303124/b5b36f23-9cf5-48bb-bcc1-391b8c09c609)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/28)
<!-- Reviewable:end -->
