### PR TITLE
DI-1216 - change reference track defaults

### DIFF
--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -5,11 +5,13 @@ build_37_urls = {
         "id": "hg19",
         "name": "Human (GRCh37/hg19)",
         "fastaURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta",
-        "indexURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai",
-        "cytobandURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt",
-        "aliasURL": (
-            "https://s3.amazonaws.com/igv.org.genomes/hg19/hg19_alias.tab"
+        "indexURL": (
+            "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai"
         ),
+        "cytobandURL": (
+            "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt"
+        ),
+        "aliasURL": "https://s3.amazonaws.com/igv.org.genomes/hg19/hg19_alias.tab",
     },
     "tracks": [
         {
@@ -17,7 +19,9 @@ build_37_urls = {
             "format": "refgene",
             "id": "hg19_genes",
             "url": "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.sorted.txt.gz",
-            "indexURL": "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.sorted.txt.gz.tbi",
+            "indexURL": (
+                "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.sorted.txt.gz.tbi"
+            ),
             "visibilityWindow": -1,
             "supportsWholeGenome": False,
             "removable": False,
@@ -33,11 +37,11 @@ build_38_urls = {
         "name": "Human (GRCh38/hg38)",
         "fastaURL": "https://igv.org/genomes/data/hg38/hg38.fa",
         "indexURL": "https://igv.org/genomes/data/hg38/hg38.fa.fai",
-        "cytobandURL": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBandIdeo.txt.gz",
-        "aliasURL": "https://igv.org/genomes/data/hg38/hg38_alias.tab",
-        "twoBitURL": (
-            "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.2bit"
+        "cytobandURL": (
+            "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBandIdeo.txt.gz"
         ),
+        "aliasURL": "https://igv.org/genomes/data/hg38/hg38_alias.tab",
+        "twoBitURL": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.2bit",
         "chromSizesURL": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.chrom.sizes",
     },
     "tracks": [
@@ -53,7 +57,9 @@ build_38_urls = {
         {
             "name": "Refseq Select",
             "format": "refgene",
-            "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeqSelect.txt.gz",
+            "url": (
+                "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeqSelect.txt.gz"
+            ),
             "indexed": False,
             "infoURL": "https://www.ncbi.nlm.nih.gov/gene/?term=$$",
             "type": "annotation",
@@ -64,7 +70,7 @@ build_38_urls = {
             "format": "refgene",
             "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeq.txt.gz",
             "type": "annotation",
-            "height": 150,
+            "height": 50,
         },
     ],
 }

--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -52,7 +52,7 @@ build_38_urls = {
             "visibilityWindow": -1,
             "type": "annotation",
             "height": 50,
-            "color": "rgb(255, 41, 135)",
+            "color": "rgb(185, 8, 8)",
         },
         {
             "name": "Refseq Select",
@@ -70,7 +70,7 @@ build_38_urls = {
             "format": "refgene",
             "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeq.txt.gz",
             "type": "annotation",
-            "height": 50,
+            "height": 100,
         },
     ],
 }

--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -42,21 +42,22 @@ build_38_urls = {
     },
     "tracks": [
         {
+            "name": "MANE Transcripts",
+            "format": "bigbed",
+            "url": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/mane/mane.bb",
+            "visibilityWindow": -1,
+            "type": "annotation",
+            "height": 50,
+            "color": "rgb(255, 41, 135)",
+        },
+        {
             "name": "Refseq Select",
             "format": "refgene",
             "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeqSelect.txt.gz",
             "indexed": False,
             "infoURL": "https://www.ncbi.nlm.nih.gov/gene/?term=$$",
             "type": "annotation",
-            "height": 150,
-        },
-        {
-            "name": "MANE Transcripts",
-            "format": "bigbed",
-            "url": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/mane/mane.bb",
-            "visibilityWindow": -1,
-            "type": "annotation",
-            "height": 150,
+            "height": 50,
         },
         {
             "name": "Refseq All",


### PR DESCRIPTION
- change MANE default colour
- move MANE to top reference track
- bump RefSeq all track to height 100
![image](https://github.com/user-attachments/assets/c3152f17-948a-430f-aaf4-4d2fb19cc055)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/43)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted attributes for track entries, including height modifications for "MANE Transcripts" and "Refseq All".
	- Removed and reformatted the "Refseq Select" entry in the track list.

- **Chores**
	- Reformatted URLs in the `build_37_urls` and `build_38_urls` dictionaries for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->