### PR TITLE
Fix GRCh38 bug where reports aren't populated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 *pyc
+/venv
+/__pycache__/
+# Ignore Python bytecode files
+# Ignore virtual environment directories
+# Ignore cache directories
+# Ignore Jupyter Notebook checkpoints
+.ipynb_checkpoints
+# Ignore log files
+*.log
+

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_artemis",
   "summary": "Gathers required files and creates file containing urls for them",
   "dxapi": "1.0.0",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "inputSpec": [
     {
       "name": "snv_path",

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_artemis",
   "summary": "Gathers required files and creates file containing urls for them",
   "dxapi": "1.0.0",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "inputSpec": [
     {
       "name": "snv_path",

--- a/resources/home/dnanexus/eggd_artemis.py
+++ b/resources/home/dnanexus/eggd_artemis.py
@@ -50,7 +50,7 @@ def main(
     # Gather required SNV files if SNV path is provided
     if snv_path:
         logger.info("Gathering Small variant files")
-        snv_data = gather_snv_data(snv_paths=snv_path, dx_project=project_id, build=build)
+        snv_data = gather_snv_data(snv_paths=snv_path, dx_project=project_id)
 
         # If multiqc report not given, search for multiqc report
         if not multiqc_report:

--- a/resources/home/dnanexus/eggd_artemis.py
+++ b/resources/home/dnanexus/eggd_artemis.py
@@ -44,13 +44,19 @@ def main(
 
     project_name, project_id, job_output_folder = initialise_project()
 
+    # Check if the build is valid
+    if build not in [37, 38]:
+        err = f"Invalid build: {build}. Must be 37 or 38."
+        logger.error(err)
+        raise ValueError(err)
+
     snv_data = {}
     cnv_data = {}
 
     # Gather required SNV files if SNV path is provided
     if snv_path:
         logger.info("Gathering Small variant files")
-        snv_data = gather_snv_data(snv_paths=snv_path, dx_project=project_id)
+        snv_data = gather_snv_data(snv_paths=snv_path, dx_project=project_id, build=build)
 
         # If multiqc report not given, search for multiqc report
         if not multiqc_report:

--- a/resources/home/dnanexus/eggd_artemis.py
+++ b/resources/home/dnanexus/eggd_artemis.py
@@ -44,12 +44,6 @@ def main(
 
     project_name, project_id, job_output_folder = initialise_project()
 
-    # Check if the build is valid
-    if build not in [37, 38]:
-        err = f"Invalid build: {build}. Must be 37 or 38."
-        logger.error(err)
-        raise ValueError(err)
-
     snv_data = {}
     cnv_data = {}
 

--- a/resources/home/dnanexus/utils/generate.py
+++ b/resources/home/dnanexus/utils/generate.py
@@ -45,9 +45,23 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
             )
         )
 
+        unique_snv_reports = {r["describe"]["name"] for r in snv_reports}
+        unique_samples = {
+            "-".join(name.split("-")[:2]) for name in unique_snv_reports
+            }
+        no_reports_expected = len(unique_samples)
+
         snv_files = find_snv_files(snv_reports, build)
         merge(snv_data, snv_files)
 
+        no_reports_in_data = len(snv_files.keys())
+        print(snv_files.keys())
+        if no_reports_in_data != no_reports_expected:
+            raise RuntimeError(
+                f"Expected {no_reports_expected} SNV reports, "
+                f"but found {no_reports_in_data} in dict."
+            )
+        print(f"Found {no_reports_in_data} SNV reports in {path}")
     print(f"Size of snv data dict: {len(snv_data.keys())}")
 
     return snv_data
@@ -81,9 +95,23 @@ def gather_cnv_data(cnv_paths, dx_project, url_duration) -> Tuple[dict, str]:
             )
         )
 
+        unique_snv_reports = {r["describe"]["name"] for r in cnv_reports}
+        unique_samples = {
+            "-".join(name.split("-")[:2]) for name in unique_snv_reports
+            }
+        no_reports_expected = len(unique_samples)
+
         gcnv_job_info = get_cnv_call_details(cnv_reports)
         cnv_files = get_cnv_file_ids(cnv_reports, gcnv_job_info)
-
+        print(cnv_files.keys())
+        no_reports_in_data = len(cnv_files.keys())
+        # Check if the number of reports found matches the expected number
+        if no_reports_in_data != no_reports_expected:
+            raise RuntimeError(
+                f"Expected {no_reports_expected} CNV reports, "
+                f"but found {no_reports_in_data} in {path}"
+            )
+        print(f"Found {no_reports_in_data} CNV reports in {path}")
         # Get excluded intervals file
         excluded_intervals = get_excluded_intervals(gcnv_job_info)
         ex_intervals_url = make_url(

--- a/resources/home/dnanexus/utils/generate.py
+++ b/resources/home/dnanexus/utils/generate.py
@@ -18,7 +18,7 @@ from .query import (
 from .util_functions import get_excluded_intervals
 
 
-def gather_snv_data(snv_paths, dx_project, build) -> dict:
+def gather_snv_data(snv_paths, dx_project) -> dict:
     """
     Finds all xlsx reports and the associated job input files using
     query.find_snv_files from the given SNV path(s)
@@ -28,7 +28,6 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
     Args:
         snv_paths (str): comma separated string of SNV path(s) to search
         dx_project (str) : DNAnexus project ID to search
-        build (int): genome build used 37/38 to determine search logic for SNV files.
 
     Returns:
         snv_data (dict): dict of all sample SNV file data
@@ -52,7 +51,7 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
 
         no_reports_expected = len(snv_reports)
 
-        snv_files = find_snv_files(snv_reports, build)
+        snv_files = find_snv_files(snv_reports)
         merge(snv_data, snv_files)
         # Count total reports across all samples and clinical indications
         total_reports_processed = 0

--- a/resources/home/dnanexus/utils/generate.py
+++ b/resources/home/dnanexus/utils/generate.py
@@ -22,8 +22,8 @@ def gather_snv_data(snv_paths, dx_project) -> dict:
     """
     Finds all xlsx reports and the associated job input files using
     query.find_snv_files from the given SNV path(s)
-    Check if the number of reports found matches the expected number of unique
-    sample names based on the SNV report names.
+    Verify that the number of processed SNV reports matches the number of
+    `.xlsx` report files discovered in the path.
 
     Args:
         snv_paths (str): comma separated string of SNV path(s) to search

--- a/resources/home/dnanexus/utils/generate.py
+++ b/resources/home/dnanexus/utils/generate.py
@@ -22,6 +22,8 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
     """
     Finds all xlsx reports and the associated job input files using
     query.find_snv_files from the given SNV path(s)
+    Check if the number of reports found matches the expected number of unique
+    sample names based on the SNV report names.
 
     Args:
         snv_paths (str): comma separated string of SNV path(s) to search
@@ -30,6 +32,9 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
 
     Returns:
         snv_data (dict): dict of all sample SNV file data
+    Raises:
+        RuntimeError: if the number of SNV reports found does not match
+            the expected number based on unique sample names.
     """
     snv_data = {}
 
@@ -70,7 +75,10 @@ def gather_snv_data(snv_paths, dx_project, build) -> dict:
 def gather_cnv_data(cnv_paths, dx_project, url_duration) -> Tuple[dict, str]:
     """
     Finds all xlsx reports and the associated job input files from the
-    given CNV path(s)
+    given CNV path(s).
+    Check if the number of reports found matches the expected number of unique
+    sample names based on the CNV report names.
+
 
     Args:
         cnv_paths (str): comma separated string of CNV path(s) to search
@@ -80,6 +88,9 @@ def gather_cnv_data(cnv_paths, dx_project, url_duration) -> Tuple[dict, str]:
     Returns:
         cnv_data (dict): dict of all sample CNV file data
         ex_intervals_url (str): download URL for the excluded intervals file
+    Raises:
+        RuntimeError: if the number of CNV reports found does not match
+            the expected number based on unique sample names.
     """
     cnv_data = {}
 

--- a/resources/home/dnanexus/utils/generate.py
+++ b/resources/home/dnanexus/utils/generate.py
@@ -18,7 +18,7 @@ from .query import (
 from .util_functions import get_excluded_intervals
 
 
-def gather_snv_data(snv_paths, dx_project) -> dict:
+def gather_snv_data(snv_paths, dx_project, build) -> dict:
     """
     Finds all xlsx reports and the associated job input files using
     query.find_snv_files from the given SNV path(s)
@@ -26,6 +26,7 @@ def gather_snv_data(snv_paths, dx_project) -> dict:
     Args:
         snv_paths (str): comma separated string of SNV path(s) to search
         dx_project (str) : DNAnexus project ID to search
+        build (int): genome build used 37/38 to determine search logic for SNV files.
 
     Returns:
         snv_data (dict): dict of all sample SNV file data
@@ -44,7 +45,7 @@ def gather_snv_data(snv_paths, dx_project) -> dict:
             )
         )
 
-        snv_files = find_snv_files(snv_reports)
+        snv_files = find_snv_files(snv_reports, build)
         merge(snv_data, snv_files)
 
     print(f"Size of snv data dict: {len(snv_data.keys())}")

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -434,8 +434,29 @@ def find_snv_files(reports) -> dict:
         ).describe()
 
         # Get bam & bai job id from sention job metadata
-        mappings_bam = additional_calling_details["output"]["input_bam"]
-        mappings_bai = additional_calling_details["output"]["input_bai"]
+        try:
+            mappings_bam_stage = parent_details["output"]["stage-sentieon_dnaseq.mappings_bam"]
+            mappings_bam = mappings_bam_stage.get("$dnanexus_link", None)
+            mappings_bai_stage = parent_details["output"]["stage-sentieon_dnaseq.mappings_bam_bai"]
+            mappings_bai = mappings_bai_stage.get("$dnanexus_link", None)
+        except KeyError:
+            print(
+                "No mappings bam or bai found in output of sentieon_dnaseq stage"
+                f" for SNV reports workflow ({parent_analysis})"
+            )
+            mappings_bam = additional_calling_details["input"][
+                "input_bam"
+            ]
+            mappings_bai = additional_calling_details["input"]["input_bai"]
+        if not mappings_bam or not mappings_bai:
+            # If no bam or bai found in additional calling job metadata
+            # then set to None and print warning
+            mappings_bam = mappings_bai = None
+            print(
+                "No input BAM or BAI found in additional calling job metadata"
+                f" ({additional_calling_job_id}) for SNV reports workflow"
+                f" ({parent_analysis})"
+            )
 
         # Store in dictionary to return
         data = {

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -488,13 +488,21 @@ def find_snv_files(reports, build) -> dict:
             )
 
         # Check all required fields are present
-        if not all(
-            [sample, mappings_bam, mappings_bai, clinical_indication,
-             coverage_report, summary_text, snv_variant_count]
-        ):
+        if not all([
+            sample,
+            mappings_bam,
+            mappings_bai,
+            clinical_indication,
+            coverage_report,
+            summary_text
+        ]) or snv_variant_count is None:
             raise ValueError(
                 "Missing required fields in SNV report: "
                 f"{report['describe']['name']}"
+                "List of fields: "
+                f"{sample}, {mappings_bam}, {mappings_bai}, "
+                  f"{clinical_indication}, {coverage_report}, "
+                  f"{summary_text}, {snv_variant_count}"
             )
 
         # Store in dictionary to return

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -451,6 +451,7 @@ def find_snv_files(reports, build) -> dict:
             )
         # Logic for extracting bam and bai files
         mappings_bam = mappings_bai = None
+        parent_vcf_job_details = {}
         # Extract the additional regions calling job id from the vcf metadata
         if build == 38:
             # For genome build 38, the additional calling job is stored in the
@@ -473,12 +474,9 @@ def find_snv_files(reports, build) -> dict:
             sentieon_job_id = dxpy.describe(vcf_file).get(
                 "createdBy", {}
             ).get("job", None)
-            if not sentieon_job_id:
-                print("No sentieon job id found in vcf file metadata.")
-            else:
-                parent_vcf_job_details = dxpy.bindings.dxjob.DXJob(
+            parent_vcf_job_details = dxpy.bindings.dxjob.DXJob(
                     dxid=sentieon_job_id
-                ).describe()
+            ).describe()
 
         parent_dias_single_analysis = (
             parent_vcf_job_details.get("parentAnalysis", None)

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -399,7 +399,7 @@ def find_snv_files(reports, build) -> dict:
             build (int): Genome build used for SNV calling, e.g. 37 or 38.
 
         Returns:
-            data (dict): files found for sample#
+            data (dict): files found for sample
         """
         # Get sample name
         sample = report["describe"]["name"].split("_")[0]

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -428,14 +428,14 @@ def find_snv_files(reports) -> dict:
             )
 
         # Extract the sention job id from the vcf metadata
-        sention_job_id = dxpy.describe(vcf_file)["createdBy"]["job"]
-        sentieon_details = dxpy.bindings.dxjob.DXJob(
-            dxid=sention_job_id
+        additional_calling_job_id = dxpy.describe(vcf_file)["createdBy"]["job"]
+        additional_calling_details = dxpy.bindings.dxjob.DXJob(
+            dxid=additional_calling_job_id
         ).describe()
 
         # Get bam & bai job id from sention job metadata
-        mappings_bam = sentieon_details["output"]["mappings_bam"]
-        mappings_bai = sentieon_details["output"]["mappings_bam_bai"]
+        mappings_bam = additional_calling_details["output"]["input_bam"]
+        mappings_bai = additional_calling_details["output"]["input_bai"]
 
         # Store in dictionary to return
         data = {

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -457,12 +457,16 @@ def find_snv_files(reports) -> dict:
         parent_vcf_job_details = dxpy.bindings.dxjob.DXJob(
             dxid=vcf_creation_job_id
         ).describe()
-
-        parent_dias_single_analysis = (
+        # Get the parent analysis id of the vcf job
+        parent_dias_single_analysis_id = (
             parent_vcf_job_details.get("parentAnalysis", None)
             )
+        if not parent_dias_single_analysis:
+            raise RuntimeError("No parent analysis found for dias-single workflow.")
+
+        # Get the parent analysis details
         dias_single_analysis_details = dxpy.bindings.dxanalysis.DXAnalysis(
-                dxid=parent_dias_single_analysis
+                dxid=parent_dias_single_analysis_id
             ).describe()
 
         if dias_single_analysis_details:

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -347,13 +347,12 @@ def get_cnv_file_ids(reports, gcnv_dict) -> dict:
     return cnv_data
 
 
-def find_snv_files(reports, build) -> dict:
+def find_snv_files(reports) -> dict:
     """
     Gather files related to SNV reports
 
     Args:
         reports (list): List of SNV report dxpy describe dicts
-        build (int): Genome build used for SNV calling, e.g. 37 or 38.
 
     Returns:
         snv_data (dict): Nested dictionary of files with sample name
@@ -390,13 +389,12 @@ def find_snv_files(reports, build) -> dict:
     }
     """
 
-    def _find(report, build):
+    def _find(report):
         """
         Find files for single sample
 
         Args:
             report (dict): dx describe return for single sample
-            build (int): Genome build used for SNV calling, e.g. 37 or 38.
 
         Returns:
             data (dict): files found for sample
@@ -535,7 +533,7 @@ def find_snv_files(reports, build) -> dict:
     with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
         # submit jobs mapping each id to describe call
         concurrent_jobs = {
-            executor.submit(_find, report, build): report for report in reports
+            executor.submit(_find, report): report for report in reports
         }
 
         for future in concurrent.futures.as_completed(concurrent_jobs):

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -322,6 +322,8 @@ def get_cnv_file_ids(reports, gcnv_dict) -> dict:
                 print(
                     f"Error getting data for {concurrent_jobs[future]}: {exc}"
                 )
+                # Propagate the exception to the caller so doesn't silently fail.
+                raise exc
 
     return cnv_data
 

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -462,7 +462,10 @@ def find_snv_files(reports) -> dict:
             parent_vcf_job_details.get("parentAnalysis", None)
             )
         if not parent_dias_single_analysis_id:
-            raise RuntimeError("No parent analysis found for dias-single workflow.")
+            raise RuntimeError(
+                "No parent analysis found for dias-single workflow. "
+                f"Sample: {sample}, VCF job id: {vcf_creation_job_id}"
+                )
 
         # Get the parent analysis details
         dias_single_analysis_details = dxpy.bindings.dxanalysis.DXAnalysis(

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -487,6 +487,16 @@ def find_snv_files(reports, build) -> dict:
                 "No parent analysis found for dias single workflow."
             )
 
+        # Check all required fields are present
+        if not all(
+            [sample, mappings_bam, mappings_bai, clinical_indication,
+             coverage_report, summary_text, snv_variant_count]
+        ):
+            raise ValueError(
+                "Missing required fields in SNV report: "
+                f"{report['describe']['name']}"
+            )
+
         # Store in dictionary to return
         data = {
             "sample": sample,

--- a/resources/home/dnanexus/utils/query.py
+++ b/resources/home/dnanexus/utils/query.py
@@ -461,7 +461,7 @@ def find_snv_files(reports) -> dict:
         parent_dias_single_analysis_id = (
             parent_vcf_job_details.get("parentAnalysis", None)
             )
-        if not parent_dias_single_analysis:
+        if not parent_dias_single_analysis_id:
             raise RuntimeError("No parent analysis found for dias-single workflow.")
 
         # Get the parent analysis details
@@ -479,7 +479,7 @@ def find_snv_files(reports) -> dict:
             except KeyError as err:
                 print(
                     "No mappings bam or bai found in output of sentieon_dnaseq stage"
-                    f" for dias single workflow ({parent_dias_single_analysis})"
+                    f" for dias single workflow ({parent_dias_single_analysis_id})"
                 )
                 raise err
         else:


### PR DESCRIPTION
This pull request introduces a fix for a bug identified in GRCh38 where no SNV reports were added to the artemis excel.
It also added additional error handling.
There is also an additional sense check for the number of reports found in find_snv_files and find_cnv_file_ids match the number of reports present in the DNAnexus path.

Changes:
- Fixes _find helper functions to use new logic for b37/b38 to find the correct dias_single workflow and bams outputted.
- Added error handling for _find helper functions.
- Added check for genome build.
- bumped version.
- Added checks for number of SNV/CNV reports found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_artemis/46)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated version number to 1.7.0.
	- Expanded ignore patterns for common Python files and directories, with improved comments for clarity.

- **Bug Fixes**
	- Improved validation to ensure all expected report files are processed, raising clear errors if mismatches occur.
	- Enhanced error collection and reporting during concurrent processing of report files, with detailed summaries of any failures.

- **Refactor**
	- Improved clarity and robustness in extracting and validating report metadata, with clearer variable naming and stricter checks for required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->